### PR TITLE
add support for incident.io integration via annotations

### DIFF
--- a/config/samples/prometheusrules/monitoring.coreos.com_prometheusrules.yaml
+++ b/config/samples/prometheusrules/monitoring.coreos.com_prometheusrules.yaml
@@ -35,3 +35,17 @@ spec:
           for: 5m
           annotations:
             cxMinNonNullValuesPercentage: "20"
+    - name: example.rules3
+      interval: "70s"
+      rules:
+        - record: ExampleRecord
+          expr: vector(3)
+        - record: ExampleRecord
+          expr: vector(4)
+        - alert: app-latency
+          expr: histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter="source",destination_service=~"ingress-annotation-test-svc.example-app.svc.cluster.local"}[1m])) by (le, destination_workload)) > 0.2
+          for: 5m
+          annotations:
+            cxMinNonNullValuesPercentage: "20"
+            cxIntegrationName: "test"
+            notifyToIncidentIo: "true"

--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -326,6 +326,8 @@ func prometheusInnerRuleToCoralogixAlert(prometheusRule prometheus.Rule) coralog
 			severityLevel = coralogixv1alpha1.AlertSeverityError
 		case "critical":
 			severityLevel = coralogixv1alpha1.AlertSeverityCritical
+		default:
+			severityLevel = coralogixv1alpha1.AlertSeverityInfo
 		}
 	} else {
 		severityLevel = coralogixv1alpha1.AlertSeverityInfo

--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -279,14 +279,26 @@ func prometheusRuleToRuleGroupSet(prometheusRule *prometheus.PrometheusRule) (co
 
 func prometheusInnerRuleToCoralogixAlert(prometheusRule prometheus.Rule) coralogixv1alpha1.AlertSpec {
 	var notificationPeriod int
+	var notifyToIncidentIo bool
 	var integrationNamePointer *string
 	var severityLevel coralogixv1alpha1.AlertSeverity
+
+	incidentIoIntegrationName := "incident-io"
 
 	integrationName, ok := prometheusRule.Annotations["cxIntegrationName"]
 	if !ok {
 		integrationNamePointer = nil
 	} else {
 		integrationNamePointer = &integrationName
+	}
+
+	notifyToIncidentIoAnnotation, ok := prometheusRule.Annotations["notifyToIncidentIo"]
+	if !ok {
+		notifyToIncidentIo = false
+	} else {
+		if notifyToIncidentIoAnnotation == "on" || notifyToIncidentIoAnnotation == "true" {
+			notifyToIncidentIo = true
+		}
 	}
 	if cxNotifyEveryMin, ok := prometheusRule.Annotations["cxNotifyEveryMin"]; ok {
 		notificationPeriod, _ = strconv.Atoi(cxNotifyEveryMin)
@@ -319,16 +331,25 @@ func prometheusInnerRuleToCoralogixAlert(prometheusRule prometheus.Rule) coralog
 		severityLevel = coralogixv1alpha1.AlertSeverityInfo
 	}
 
+	notifications := []coralogixv1alpha1.Notification{
+		{
+			RetriggeringPeriodMinutes: int32(notificationPeriod),
+			IntegrationName:           integrationNamePointer,
+		},
+	}
+
+	if notifyToIncidentIo {
+		notifications = append(notifications, coralogixv1alpha1.Notification{
+			RetriggeringPeriodMinutes: int32(notificationPeriod),
+			IntegrationName:           &incidentIoIntegrationName,
+		})
+	}
+
 	return coralogixv1alpha1.AlertSpec{
 		Severity: severityLevel,
 		NotificationGroups: []coralogixv1alpha1.NotificationGroup{
 			{
-				Notifications: []coralogixv1alpha1.Notification{
-					{
-						RetriggeringPeriodMinutes: int32(notificationPeriod),
-						IntegrationName:           integrationNamePointer,
-					},
-				},
+				Notifications: notifications,
 			},
 		},
 		Name:   prometheusRule.Alert,

--- a/tests/e2e/promatheusrules/00-install.yaml
+++ b/tests/e2e/promatheusrules/00-install.yaml
@@ -31,3 +31,17 @@ spec:
           for: 5m
           annotations:
             cxMinNonNullValuesPercentage: "20"
+    - name: example.rules3
+      interval: "70s"
+      rules:
+        - record: ExampleRecord
+          expr: vector(3)
+        - record: ExampleRecord
+          expr: vector(4)
+        - alert: app-latency
+          expr: histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter="source",destination_service=~"ingress-annotation-test-svc.example-app.svc.cluster.local"}[1m])) by (le, destination_workload)) > 0.2
+          for: 5m
+          annotations:
+            cxMinNonNullValuesPercentage: "20"
+            cxIntegrationName: "test"
+            notifyToIncidentIo: "true"

--- a/tests/e2e/promatheusrules/03-assert.yaml
+++ b/tests/e2e/promatheusrules/03-assert.yaml
@@ -1,0 +1,40 @@
+apiVersion: coralogix.com/v1alpha1
+kind: Alert
+metadata:
+  finalizers:
+    - alert.coralogix.com/finalizer
+  labels:
+    app.kubernetes.io/managed-by: prometheus-example-rules
+  name: prometheus-example-rules-app-latency-1
+  namespace: default
+  ownerReferences:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      name: prometheus-example-rules
+status:
+  active: true
+  alertType:
+    metric:
+      promql:
+        conditions:
+          alertWhen: More
+          minNonNullValuesPercentage: 0
+          sampleThresholdPercentage: 100
+          threshold: "0"
+          timeWindow: FiveMinutes
+        searchQuery:
+          histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter="source",destination_service=~"ingress-annotation-test-svc.example-app.svc.cluster.local"}[1m]))
+          by (le, destination_workload)) > 0.2
+  name: app-latency
+  notificationGroups:
+    - notifications:
+        - notifyOn: TriggeredOnly
+          integrationName: "test"
+          retriggeringPeriodMinutes: 5
+        - notifyOn: TriggeredOnly
+          integrationName: "incident-io"
+          retriggeringPeriodMinutes: 5
+  severity: Info
+  showInInsight:
+    notifyOn: TriggeredOnly
+    retriggeringPeriodMinutes: 5


### PR DESCRIPTION
Allow to add an annotation to prometheus rules (to support Sloth) to enable integration for incident.io.